### PR TITLE
chore: declare type definitions in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   ],
   "main": "./dist/altcha.umd.cjs",
   "module": "./dist/altcha.js",
+  "types": "./dist/altcha.d.ts",
   "exports": {
     ".": {
       "import": "./dist/altcha.js",


### PR DESCRIPTION
- Added `"types": "./dist/altcha.d.ts"` to `package.json` to expose type definitions.
