### PR TITLE
fix: remove svelte dependency from public TypeScript declarations

### DIFF
--- a/dist/altcha.d.ts
+++ b/dist/altcha.d.ts
@@ -1,4 +1,3 @@
-import type { Writable } from 'svelte/store';
 export {};
 
 declare module 'altcha';
@@ -9,7 +8,11 @@ declare global {
   var altchaI18n: {
     get: (language: string) => Record<string, string>;
     set: (language: string, translation: Record<string, string>) => void;
-    store: Writable<Record<string, Record<string, string>>>;
+    store: {
+      set(this: void, value: Record<string, Record<string, string>>): void;
+      update(this: void, updater: (value: Record<string, Record<string, string>>) => Record<string, Record<string, string>>): void;
+      subscribe(this: void, run: (value: Record<string, Record<string, string>>) => void, invalidate?: () => void): () => void;
+    };
   };
 
   type AltchaState = 'error' | 'expired' | 'verified' | 'verifying' | 'unverified';

--- a/dist/altcha.i18n.d.ts
+++ b/dist/altcha.i18n.d.ts
@@ -1,4 +1,3 @@
-import type { Writable } from 'svelte/store';
 export {};
 
 declare module 'altcha';
@@ -9,7 +8,11 @@ declare global {
   var altchaI18n: {
     get: (language: string) => Record<string, string>;
     set: (language: string, translation: Record<string, string>) => void;
-    store: Writable<Record<string, Record<string, string>>>;
+    store: {
+      set(this: void, value: Record<string, Record<string, string>>): void;
+      update(this: void, updater: (value: Record<string, Record<string, string>>) => Record<string, Record<string, string>>): void;
+      subscribe(this: void, run: (value: Record<string, Record<string, string>>) => void, invalidate?: () => void): () => void;
+    };
   };
 
   type AltchaState = 'error' | 'expired' | 'verified' | 'verifying' | 'unverified';

--- a/dist_external/altcha.d.ts
+++ b/dist_external/altcha.d.ts
@@ -1,4 +1,3 @@
-import type { Writable } from 'svelte/store';
 export {};
 
 declare module 'altcha';
@@ -9,7 +8,11 @@ declare global {
   var altchaI18n: {
     get: (language: string) => Record<string, string>;
     set: (language: string, translation: Record<string, string>) => void;
-    store: Writable<Record<string, Record<string, string>>>;
+    store: {
+      set(this: void, value: Record<string, Record<string, string>>): void;
+      update(this: void, updater: (value: Record<string, Record<string, string>>) => Record<string, Record<string, string>>): void;
+      subscribe(this: void, run: (value: Record<string, Record<string, string>>) => void, invalidate?: () => void): () => void;
+    };
   };
 
   type AltchaState = 'error' | 'expired' | 'verified' | 'verifying' | 'unverified';

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,4 +1,3 @@
-import type { Writable } from 'svelte/store';
 export {};
 
 declare module 'altcha';
@@ -9,7 +8,11 @@ declare global {
   var altchaI18n: {
     get: (language: string) => Record<string, string>;
     set: (language: string, translation: Record<string, string>) => void;
-    store: Writable<Record<string, Record<string, string>>>;
+    store: {
+      set(this: void, value: Record<string, Record<string, string>>): void;
+      update(this: void, updater: (value: Record<string, Record<string, string>>) => Record<string, Record<string, string>>): void;
+      subscribe(this: void, run: (value: Record<string, Record<string, string>>) => void, invalidate?: () => void): () => void;
+    };
   };
 
   type AltchaState = 'error' | 'expired' | 'verified' | 'verifying' | 'unverified';


### PR DESCRIPTION
Fixes this error in a TypeScript project that doesn’t use Svelte:

`node_modules/.pnpm/altcha@2.0.2/node_modules/altcha/dist/altcha.d.ts(1,31): error TS2307: Cannot find module 'svelte/store' or its corresponding type declarations.`